### PR TITLE
Change Templating Engine To Rinja

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,56 +61,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "askama"
-version = "0.13.0"
-source = "git+https://github.com/djc/askama.git#382b5f6a4e3e50676283957ed38d8f719ad6b5df"
-dependencies = [
- "askama_derive",
- "askama_escape",
- "humansize",
- "num-traits",
- "percent-encoding",
-]
-
-[[package]]
-name = "askama_axum"
-version = "0.5.0"
-source = "git+https://github.com/djc/askama.git#382b5f6a4e3e50676283957ed38d8f719ad6b5df"
-dependencies = [
- "askama",
- "axum-core",
- "http",
-]
-
-[[package]]
-name = "askama_derive"
-version = "0.13.0"
-source = "git+https://github.com/djc/askama.git#382b5f6a4e3e50676283957ed38d8f719ad6b5df"
-dependencies = [
- "askama_parser",
- "basic-toml",
- "mime",
- "mime_guess",
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.71",
-]
-
-[[package]]
-name = "askama_escape"
-version = "0.11.0"
-source = "git+https://github.com/djc/askama.git#382b5f6a4e3e50676283957ed38d8f719ad6b5df"
-
-[[package]]
-name = "askama_parser"
-version = "0.3.0"
-source = "git+https://github.com/djc/askama.git#382b5f6a4e3e50676283957ed38d8f719ad6b5df"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,11 +636,11 @@ dependencies = [
 name = "htmx-todo"
 version = "0.1.0"
 dependencies = [
- "askama",
- "askama_axum",
  "axum",
  "axum-embed",
  "axum-htmx",
+ "rinja",
+ "rinja_axum",
  "rust-embed",
  "serde",
  "sqlx",
@@ -1075,6 +1025,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "once_map"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa7085055bbe9c8edbd982048dbcf8181794d4a81cb04a11931673e63cc18dc6"
+dependencies = [
+ "ahash",
+ "hashbrown",
+ "parking_lot",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1260,55 @@ name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "rinja"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d47a46d7729e891c8accf260e9daa02ae6d570aa2a94fb1fb27eb5364a2323"
+dependencies = [
+ "humansize",
+ "num-traits",
+ "percent-encoding",
+ "rinja_derive",
+]
+
+[[package]]
+name = "rinja_axum"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61c87c2472481b0476fd28a2f3f7b28b0e709dade9894c7d2e21c8f1e94c3af"
+dependencies = [
+ "axum-core",
+ "http",
+ "rinja",
+]
+
+[[package]]
+name = "rinja_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dae9afe59d58ed8d988d67d1945f3638125d2fd2104058399382e11bd3ea2a"
+dependencies = [
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "once_map",
+ "proc-macro2",
+ "quote",
+ "rinja_parser",
+ "serde",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "rinja_parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1771c78cd5d3b1646ef8d8f2ed100db936e8b291d3cc06e92a339ff346858c"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "rsa"
@@ -1740,6 +1751,12 @@ dependencies = [
  "url",
  "urlencoding",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stringprep"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-askama = { git = "https://github.com/djc/askama.git", features = ["with-axum"] }
-askama_axum = { git = "https://github.com/djc/askama.git" }
+rinja = { version = "0.2.0", features = ["with-axum"] }
+rinja_axum = { version = "0.2.0" }
 axum = { version = "0.7.5", features = ["macros"] }
 axum-embed = "0.1.0"
 axum-htmx = { version = "0.6.0", features = ["auto-vary", "guards"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ enum Error {
     #[error(transparent)]
     Sql(#[from] sqlx::Error),
     #[error(transparent)]
-    Askama(#[from] askama::Error),
+    Rinja(#[from] rinja::Error),
 }
 
 impl IntoResponse for Error {

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -1,4 +1,3 @@
-use askama::Template;
 use axum::{
     extract::{Path, State},
     response::{IntoResponse, Redirect},
@@ -6,6 +5,7 @@ use axum::{
     Form, Router,
 };
 use axum_htmx::HxRequest;
+use rinja::Template;
 use serde::Deserialize;
 
 use crate::{Error, SharedState};

--- a/templates/todos.html
+++ b/templates/todos.html
@@ -11,7 +11,7 @@
 </form>
 <ol hx-target="this">
     {% block list %}
-    {% for todo in todos|as_ref %}
+    {% for todo in todos|ref %}
     <li>
         {% if todo.edit %}
         <form method="post" action="/todos/{{todo.id}}">


### PR DESCRIPTION
Currently the project uses Askama for HTML template rendering, however it was using the main branch directly due to block fragment rendering being in a non-released commit. Rinja is a fork of Askama to fix its lack of maintainance.